### PR TITLE
feat: add react-addons-css-transition-group to externals for the CDN

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,6 +41,12 @@ module.exports = {
                 "commonjs": true,
                 "commonjs2": true,
                 "amd": true
+            },
+            "react-addons-css-transition-group": {
+                "root": [ "React","addons", "CSSTransitionGroup" ],
+                "commonjs": true,
+                "commonjs2": true,
+                "amd": true
             }
         },
         plugins: [


### PR DESCRIPTION
Add React CSSTransitionGroup to the externals for the CDN build to avoid loading two React versions
