### PR TITLE
fix(npm-packaging): add ReactTranstionGroup package dependency as externals

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,7 +67,7 @@ module.exports = {
 
         output: { libraryTarget: 'commonjs2' },
 
-        externals: [ 'react', 'react-dom', 'react-addons-css-transition-group', /^\.\// ].concat(packageDependencies()),
+        externals: [ 'react', 'react-dom', 'react-addons-transition-group', 'react-addons-css-transition-group', /^\.\// ].concat(packageDependencies()),
 
         module: {
             loaders: [ babelLoader ]


### PR DESCRIPTION
We will need to add every react addon as external to avoid incorrect npm package bundling
