### PR TITLE
fix(e2e): support parallel execution of e2e-tests

### DIFF
--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -36,6 +36,17 @@ module.exports = (function() {
                 "desiredCapabilities": {
                     "browserName": "chrome"
                 }
+            },
+            "parallel": {
+                "desiredCapabilities": {
+                    "browserName": "chrome"
+                },
+                "test_workers": {
+                    "enabled": true,
+                    "workers": "auto"
+                },
+                "skip_testcases_on_fail": false,
+                "parallel_process_delay": 20
             }
         }
     };


### PR DESCRIPTION
To execute the e2e-tests in parallel mode, use the `parallel` environment by passing `-e parallel` as an argument when executing the e2e command: 

> gulp e2e -e parallel