### PR TITLE
feat: bump typescript-tasks version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "React"
   ],
   "dependencies": {
-    "@progress/kendo-typescript-tasks": "^3.5.3",
+    "@progress/kendo-typescript-tasks": "^4.0.0",
     "@telerik/eslint-config": "1.1.0",
     "enzyme": "^3.1.0",
     "enzyme-adapter-react-16": "^1.0.1",


### PR DESCRIPTION
The new version brings fixes for typedoc api generation. The ts configuration is now targeting es6 instead of es5.
There is no need for (Object as any).assign hacks and so.