### PR TITLE
fix: pass options for api generation

### DIFF
--- a/gulp-tasks.js
+++ b/gulp-tasks.js
@@ -5,13 +5,17 @@ const tsTasks = require('@progress/kendo-typescript-tasks');
 const selenium = require('selenium-standalone');
 const seleniumConfig = require('./selenium.conf.js');
 const nightwatch = './node_modules/.bin/nightwatch';
-
+/**
+* Add more relaxing options when generating api-docs,
+* temporary solves the problem with the missing return type for the React.Component methods.
+*/
+const apiConfig = { warningsAsErrors: false };
 const karmaConfigPath = path.join(__dirname, 'karma.conf.js');
 const webpackConfig = require('./webpack.config.js');
 
 /* eslint-disable no-console */
 module.exports = (gulp, libraryName, compilerPath, basePath) => {
-    tsTasks(gulp, libraryName, karmaConfigPath, compilerPath, null, webpackConfig, { basePath: (basePath || ' ') });
+    tsTasks(gulp, libraryName, karmaConfigPath, compilerPath, apiConfig, webpackConfig, { basePath: (basePath || ' ') });
 
     gulp.task('e2e', (done) => {
         console.log(`Installing selenium standalone server and chrome web driver`);


### PR DESCRIPTION
Povide more relaxing options for the api generation, such as warnings do not turn into errors