### PR TITLE
fix: add support for api options to be passed to typescript-tasks

### DIFF
--- a/gulp-tasks.js
+++ b/gulp-tasks.js
@@ -10,10 +10,12 @@ const apiConfig = require('./api.conf.js');
 const karmaConfigPath = path.join(__dirname, 'karma.conf.js');
 const webpackConfig = require('./webpack.config.js');
 const docsServer = require('@telerik/kendo-common-tasks/docs-server');
+const deepAssign = require('lodash.merge');
 
 /* eslint-disable no-console */
-module.exports = (gulp, libraryName, compilerPath, basePath) => {
-    tsTasks(gulp, libraryName, karmaConfigPath, compilerPath, apiConfig, webpackConfig, { basePath: (basePath || ' ') });
+module.exports = (gulp, libraryName, compilerPath, basePath, options = {}) => { // eslint-disable-line max-params
+    const apiOptions = deepAssign({}, apiConfig, options.apiConfig);
+    tsTasks(gulp, libraryName, karmaConfigPath, compilerPath, apiOptions, webpackConfig, { basePath: (basePath || ' ') });
 
     gulp.task('e2e', (done) => {
         console.log(`Installing selenium standalone server and chrome web driver`);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "enzyme": "^3.1.0",
     "enzyme-adapter-react-16": "^1.0.1",
     "karma-mocha-reporter": "^2.2.5",
+    "lodash.merge": "^4.6.0",
     "nightwatch": "^0.9.16",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",


### PR DESCRIPTION
The deepAssign dependency has been resolved and was working properly, so i let it be.