### PR TITLE
fix(api): thread components which inherit from React components as co…

### DIFF
--- a/api.conf.js
+++ b/api.conf.js
@@ -18,7 +18,7 @@ function isInheritedMember(member) {
 
 function isClassComponents(member) {
     return member.kindString === "Class" &&
-        (member.extendedTypes || []).some(c => componentRegExp.test(c.name));
+        ((member.extendedTypes || []).some(c => componentRegExp.test(c.name)) || (member.children || []).some(c => isInheritedMember(c)));
 }
 
 const isSFComponent = (member) => {


### PR DESCRIPTION
…mponents

Currently only components which inherit from React.Components or are SFC are marked as components.
The following change allow components which extend components which are React.Components to be
threaded as such.