### PR TITLE
fix: fix unexpected behavior where session is killed on assert fail making logs inaccessible

### DIFF
--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -52,6 +52,7 @@ module.exports = (function() {
                 },
                 "desiredCapabilities": desiredCapabilities,
                 "exclude": [ "./utils/**/*.*" ],
+                "end_session_on_fail": false,
                 "skip_testcases_on_fail": false
             },
             "chrome": {
@@ -64,6 +65,7 @@ module.exports = (function() {
                     "enabled": true,
                     "workers": "auto"
                 },
+                "end_session_on_fail": false,
                 "skip_testcases_on_fail": false,
                 "parallel_process_delay": 20
             }


### PR DESCRIPTION
The default behavior of nightwatch on assertion fail is to terminate the test session. This is usually ok, but as a side effect the logs, including browser logs, become inaccessible. But we want to see them now when a test fails.

With the setting change in this commit, the afterEach handler I am developing can access them even if a test fails

Tested locally for both serial and parallel mode. Not tested on CI