### PR TITLE
fix: remove setting to confirm if it causes mеmory issues on CI

### DIFF
--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -52,7 +52,6 @@ module.exports = (function() {
                 },
                 "desiredCapabilities": desiredCapabilities,
                 "exclude": [ "./utils/**/*.*" ],
-                "end_session_on_fail": false,
                 "skip_testcases_on_fail": false
             },
             "chrome": {
@@ -65,7 +64,6 @@ module.exports = (function() {
                     "enabled": true,
                     "workers": "auto"
                 },
-                "end_session_on_fail": false,
                 "skip_testcases_on_fail": false,
                 "parallel_process_delay": 20
             }


### PR DESCRIPTION
The setting I just removed in this commit is required for the work on screenshots and browser logs. But currently Kendo React e2e tests cause serious memory issues on CI, so we would like to move this change through the flow into master, so we could test if this setting is the culprit of our Jenkins difficulties