### PR TITLE
fix: restore end_session_on_fail setting in nightwatch config

### DIFF
--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -52,6 +52,7 @@ module.exports = (function() {
                 },
                 "desiredCapabilities": desiredCapabilities,
                 "exclude": [ "./utils/**/*.*" ],
+                "end_session_on_fail": false,
                 "skip_testcases_on_fail": false
             },
             "chrome": {
@@ -64,6 +65,7 @@ module.exports = (function() {
                     "enabled": true,
                     "workers": "auto"
                 },
+                "end_session_on_fail": false,
                 "skip_testcases_on_fail": false,
                 "parallel_process_delay": 20
             }


### PR DESCRIPTION
FYI

We did some testing and validated that yesterday's heap memory issues on Jenkins were not a result of end_session_on_fail. I will restore the setting and move it through the flow.