### PR TITLE
Remove "examples" from start task entry point

### DIFF
--- a/tasks/start.js
+++ b/tasks/start.js
@@ -15,7 +15,7 @@ module.exports = function registerStartTask(gulp) {
     gulp.task('start', (done) => {
         const config = Object.assign({}, startWebpackConfig);
 
-        config.entry = addHMR(`examples/**/${argv.e || '*'}.tsx`);
+        config.entry = addHMR(argv.e || 'examples/**/*.tsx');
 
         startWebpackDevServer(config, done);
     });
@@ -25,7 +25,7 @@ function addHMR(path) {
     return glob.sync(path).reduce(addHMRCallback, {});
 }
 function addHMRCallback(entries, name) {
-    entries[name.replace(/^examples(\\|\/)/, '').replace(/\.(tsx?|jsx)$/, '')] = [
+    entries[name.replace(/\.(tsx?|jsx)$/, '')] = [
         devServerPath,
         devServerClientPath,
         `./${name}`

--- a/webpack/start.config.js
+++ b/webpack/start.config.js
@@ -40,7 +40,7 @@ module.exports = {
         alias: { [ pkg.name ]: path.resolve('./src/main') }
     },
     devtool: 'cheap-module-eval-source-map',
-    output: { publicPath: '/', path: '/', filename: 'examples/[name].js' },
+    output: { publicPath: '/', path: '/', filename: '[name].js' },
     plugins: [
         new BrowserSyncPlugin(
             // BrowserSync options


### PR DESCRIPTION
The change will allow us to run examples outside 'examples' folder.

e.g.
`gulp start -e 'examples-dev/autocomplete/form.tsx'`