### PR TITLE
test: shorter selenium timeout

### DIFF
--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -41,7 +41,7 @@ module.exports = (function() {
         "test_settings": {
             "default": {
                 "request_timeout_options": {
-                    "timeout": 30000,
+                    "timeout": 4000,
                     "retry_attempts": 5
                 },
                 "launch_url": `http://${localhost}`,


### PR DESCRIPTION
Tested locally. Sometimes requests to selenium server hang. This PR shortens the amount we wait for them so we actually hit the retry mechanism instead of timeout failing. Hopefully this will make some random errors occur more rarely