### PR TITLE
fix: react-dom and react-dom/server externals

### DIFF
--- a/webpack/cdn.config.js
+++ b/webpack/cdn.config.js
@@ -34,9 +34,17 @@ const externals = externalsDependencies.reduce((accumulator, extKey) => {
          * The UMD distributions for in-browser use expect the following format:
          * @progress/kendo-react-intl => KendoReactIntl
         */
-        const value = extType === 'root' ? extKey.split(splitter).filter(part => !part.match(/@progress|@telerik/)).map(part => upperFirst(part)).join('') : extKey;
+        if (extType === 'root') {
+            const value = extKey.split(splitter).filter(part => !part.match(/@progress|@telerik/)).map(part => upperFirst(part)).join('');
 
-        accumulator[extKey][extType] = value;
+            if (value.startsWith('ReactDom')) {
+                accumulator[extKey][extType] = value.replace('ReactDom', 'ReactDOM');
+            } else {
+                accumulator[extKey][extType] = value;
+            }
+        } else {
+            accumulator[extKey][extType] = extKey;
+        }
     });
 
     return accumulator;


### PR DESCRIPTION
CDN scripts are generating using wrong externals for `ReactDOM` and `ReactDOMServer`, which makes 
cdn scripts of some components useless.

```
"react-dom": {
	"root": "ReactDom",
	"commonjs": 'react-dom',
	"commonjs2": 'react-dom',
	"amd": 'react-dom'
},
"react-dom/server": {
	"root": "ReactDomServer",
	"commonjs": 'react-dom/server',
	"commonjs2": 'react-dom/server',
	"amd": 'react-dom/server'
},
```
should be
```
"react-dom": {
	"root": "ReactDOM",
	"commonjs": 'react-dom',
	"commonjs2": 'react-dom',
	"amd": 'react-dom'
},
"react-dom/server": {
	"root": "ReactDOMServer",
	"commonjs": 'react-dom/server',
	"commonjs2": 'react-dom/server',
	"amd": 'react-dom/server'
},
```